### PR TITLE
chore: pin formatters; justfile for recurring commands

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,8 +19,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
-      - name: Run fmt
-        run: cargo +nightly fmt --all --check
+      - run: rustup toolchain install nightly-2025-09-21 --component rustfmt
+      - run: cargo +nightly-2025-09-21 fmt --all --check
 
   clippy:
     name: clippy

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -29,4 +29,5 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: Run tests
-        run: cargo nextest run --lib --bins --no-tests=warn
+        run: cargo nextest run --lib --bins --no-tests=warn --retries 3
+

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,3 @@
+[formatting]
+indent_string = "  "
+array_trailing_comma = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ revm-interpreter = { version = "25.0.2", default-features = false }
 
 # rt
 tokio = { version = "1", default-features = false, features = [
-    "sync",
-    "time",
-    "rt-multi-thread",
-    "macros",
+  "sync",
+  "time",
+  "rt-multi-thread",
+  "macros"
 ] }
 futures = "0.3"
 
@@ -36,16 +36,16 @@ metrics-derive = "0.1"
 metrics-process = "2.4.0"
 metrics-util = "0.20.0"
 metrics-exporter-prometheus = { version = "0.17.2", default-features = false, features = [
-    "http-listener",
+  "http-listener"
 ] }
 
 # misc
 hyper = "1.7"
 axum = { version = "0.8", default-features = false, features = [
-    "http1",
-    "json",
-    "tokio",
-    "tracing",
+  "http1",
+  "json",
+  "tokio",
+  "tracing"
 ] }
 mime = "0.3"
 serde = { version = "1", features = ["derive"] }

--- a/justfile
+++ b/justfile
@@ -1,0 +1,14 @@
+# display a help message about available commands
+default:
+  @just --list --unsorted
+
+clippy:
+  cargo clippy --all-targets --all-features -- -D warnings
+
+fmt:
+  rustup toolchain install nightly-2025-09-21 --component rustfmt > /dev/null 2>&1 && \
+  cd {{justfile_directory()}} && \
+  cargo +nightly-2025-09-21 fmt
+
+test:
+  cargo nextest run --lib --bins --no-tests=warn --retries 3


### PR DESCRIPTION
Pins Rust nightly formatter and TOML formatter to reduce the number of annoying diffs.

Adds a small justfile for recurring commands: clippy, fmt, test.