### PR TITLE
fix(cli): indexer arg validation

### DIFF
--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -125,13 +125,20 @@ impl ClickhouseIndexer {
             };
         };
 
-        info!(host = %args.host, "Running with clickhouse indexer");
+        let (host, database, username, password) = (
+            args.host.expect("host is set"),
+            args.database.expect("database is set"),
+            args.username.expect("username is set"),
+            args.password.expect("password is set"),
+        );
+
+        info!(%host, "Running with clickhouse indexer");
 
         let client = ClickhouseClient::default()
-            .with_url(args.host)
-            .with_database(args.database)
-            .with_user(args.username)
-            .with_password(args.password)
+            .with_url(host)
+            .with_database(database)
+            .with_user(username)
+            .with_password(password)
             // NOTE: Validation is disabled for performance reasons, and because validation doesn't
             // support Uint256 data types.
             .with_validation(false);


### PR DESCRIPTION
Got it by some `Clap`s footguns, and indexing args were not really optional. Now they are. Unit tests are also added to test this functionality.

CLI logs:

```
#### NO CLICKHOUSE ARGS
 ~/oss/buildernet-orderflow-proxy-v2_flashbots  on lore/fix/optional-indexing  cargo run -- --user-listen-url 0.0.0.0:9754 --system-listen-url 0.0.0.0:9755 --builder-listen-url 0.0.0.0:8756 --builder-url http://0.0.0.0:2020 --builder-hub-url http://localhost:3000
   Compiling buildernet-orderflow-proxy v0.1.0 (/Users/birb/oss/buildernet-orderflow-proxy-v2_flashbots)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.08s
     Running `target/debug/buildernet-orderflow-proxy --user-listen-url '0.0.0.0:9754' --system-listen-url '0.0.0.0:9755' --builder-listen-url '0.0.0.0:8756' --builder-url 'http://0.0.0.0:2020' --builder-hub-url 'http://localhost:3000'`
2025-09-30T10:43:53.305946Z  INFO buildernet_orderflow_proxy::indexer: Running with mocked indexer
2025-09-30T10:43:53.306307Z  WARN buildernet_orderflow_proxy: No orderflow signer was configured, using a random signer. Fix this by passing `--orderflow-signer <PRIVATE KEY>`
2025-09-30T10:43:53.308121Z  INFO buildernet_orderflow_proxy: Orderflow signer configured address=0x1b1F00ce3C5fBE7A5404Fb0116A8F7ceFFBff646
Error: error sending request for url (http://localhost:3000/api/l1-builder/v1/register_credentials/orderflow_proxy)

Caused by:
   0: client error (Connect)
   1: tcp connect error
   2: Connection refused (os error 61)

Location:
    /Users/birb/oss/buildernet-orderflow-proxy-v2_flashbots/src/builderhub.rs:63:24

#### PARTIAL CLICKHOUSE ARGS
 ~/oss/buildernet-orderflow-proxy-v2_flashbots  on lore/fix/optional-indexing  cargo run -- --user-listen-url 0.0.0.0:9754 --system-listen-url 0.0.0.0:9755 --builder-listen-url 0.0.0.0:8756 --builder-url http://0.0.0.0:2020 --builder-hub-url http://localhost:3000 --clickhouse.user pronto
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.33s
     Running `target/debug/buildernet-orderflow-proxy --user-listen-url '0.0.0.0:9754' --system-listen-url '0.0.0.0:9755' --builder-listen-url '0.0.0.0:8756' --builder-url 'http://0.0.0.0:2020' --builder-hub-url 'http://localhost:3000' --clickhouse.user pronto`
error: the following required arguments were not provided:
  --clickhouse.host <HOST>
  --clickhouse.password <PASSWORD>
  --clickhouse.database <DATABASE>

Usage: buildernet-orderflow-proxy --user-listen-url <USER_LISTEN_URL> --system-listen-url <SYSTEM_LISTEN_URL> --builder-listen-url <BUILDER_LISTEN_URL> --builder-url <BUILDER_URL> --clickhouse.host <HOST> --clickhouse.user <USERNAME> --clickhouse.password <PASSWORD> --clickhouse.database <DATABASE> --builder-hub-url <BUILDER_HUB_URL>

For more information, try '--help'.

#### ALL CLICKHOUSE ARGS
 ~/oss/buildernet-orderflow-proxy-v2_flashbots  on lore/fix/optional-indexing  cargo run -- --user-listen-url 0.0.0.0:9754 --system-listen-url 0.0.0.0:9755 --builder-listen-url 0.0.0.0:8756 --builder-url http://0.0.0.0:2020 --builder-hub-url http://localhost:3000 --clickhouse.user pronto --clickhouse.password pronto --clickhouse.database pronto --clickhouse.host http://127.0.0.1:12345
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.34s
     Running `target/debug/buildernet-orderflow-proxy --user-listen-url '0.0.0.0:9754' --system-listen-url '0.0.0.0:9755' --builder-listen-url '0.0.0.0:8756' --builder-url 'http://0.0.0.0:2020' --builder-hub-url 'http://localhost:3000' --clickhouse.user pronto --clickhouse.password pronto --clickhouse.database pronto --clickhouse.host 'http://127.0.0.1:12345'`
2025-09-30T10:44:27.445219Z  INFO buildernet_orderflow_proxy::indexer: Running with clickhouse indexer host=http://127.0.0.1:12345
2025-09-30T10:44:27.646456Z  WARN buildernet_orderflow_proxy: No orderflow signer was configured, using a random signer. Fix this by passing `--orderflow-signer <PRIVATE KEY>`
2025-09-30T10:44:27.647287Z  INFO buildernet_orderflow_proxy: Orderflow signer configured address=0xA2fFaDC2B569b135a95C5Abc0095f84775E61215
2025-09-30T10:44:27.653720Z ERROR indexer: bundle tx channel closed, indexer will stop running
2025-09-30T10:44:27.653726Z ERROR indexer: transaction tx channel closed, indexer will stop running
Error: error sending request for url (http://localhost:3000/api/l1-builder/v1/register_credentials/orderflow_proxy)

Caused by:
   0: client error (Connect)
   1: tcp connect error
   2: Connection refused (os error 61)

Location:
    /Users/birb/oss/buildernet-orderflow-proxy-v2_flashbots/src/builderhub.rs:63:24

 ~/oss/buildernet-orderflow-proxy-v2_flashbots  on lore/fix/optional-indexing                                                                                                                                   1 ✘  system Node  at 12:44:27
```