### PR TITLE
feat: graceful shutdown of long-lived tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,6 +2101,7 @@ dependencies = [
  "eyre",
  "flate2",
  "futures",
+ "futures-util",
  "hyper",
  "metrics",
  "metrics-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ tokio = { version = "1", default-features = false, features = [
   "macros"
 ] }
 tokio-util = { version = "0.7.16" }
-futures = "0.3"
+futures = { version = "0.3" }
+futures-util = { version = "0.3.31" }
 
 # tracing
 tracing = "0.1"

--- a/src/indexer/click.rs
+++ b/src/indexer/click.rs
@@ -119,10 +119,7 @@ impl ClickhouseIndexer {
             token.child_token(),
         ));
         // TODO: support bundle receipts in Clickhouse.
-        let bundle_receipt_indexer_task =
-            tokio::task::spawn(
-                async move { while let Some(_b) = bundle_receipt_rx.recv().await {} },
-            );
+        tokio::task::spawn(async move { while let Some(_b) = bundle_receipt_rx.recv().await {} });
         let transaction_indexer_task = tokio::spawn(run_indexer(
             transaction_rx,
             transaction_inserter,
@@ -131,9 +128,9 @@ impl ClickhouseIndexer {
         ));
 
         OrderIndexerTasks {
-            bundle_indexer_task,
-            bundle_receipt_indexer_task,
-            transaction_indexer_task,
+            bundle_indexer_task: Some(bundle_indexer_task),
+            bundle_receipt_indexer_task: None,
+            transaction_indexer_task: Some(transaction_indexer_task),
         }
     }
 }

--- a/src/indexer/parq.rs
+++ b/src/indexer/parq.rs
@@ -183,17 +183,15 @@ impl ParquetIndexer {
 
         let receipts_writer = BundleReceiptWriter::new(writer, builder_name.clone());
 
-        let bundle_indexer_task =
-            tokio::task::spawn(async move { while let Some(_b) = bundle_rx.recv().await {} });
+        tokio::task::spawn(async move { while let Some(_b) = bundle_rx.recv().await {} });
         let bundle_receipt_indexer_task =
             tokio::spawn(run_indexer(bundle_receipt_rx, receipts_writer, token));
-        let transaction_indexer_task =
-            tokio::task::spawn(async move { while let Some(_t) = transaction_rx.recv().await {} });
+        tokio::task::spawn(async move { while let Some(_t) = transaction_rx.recv().await {} });
 
         let tasks = OrderIndexerTasks {
-            bundle_indexer_task,
-            bundle_receipt_indexer_task,
-            transaction_indexer_task,
+            bundle_indexer_task: None,
+            bundle_receipt_indexer_task: Some(bundle_receipt_indexer_task),
+            transaction_indexer_task: None,
         };
 
         Ok(tasks)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,60 @@
-use buildernet_orderflow_proxy::cli::OrderflowIngressArgs;
+use std::{ops::DerefMut, time::Duration};
+
+use buildernet_orderflow_proxy::{
+    cli::OrderflowIngressArgs,
+    statics::{SHUTDOWN_TOKEN, TASKS},
+};
 use clap::Parser;
+use futures::future::join_all;
+use tokio::signal::unix::SignalKind;
 
 #[tokio::main]
 async fn main() {
-    // When a task crashes, we crash the whole program.
+    // When a task crashes, we stop the whole program.
     let orig_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
         orig_hook(panic_info);
-        std::process::exit(1);
+
+        SHUTDOWN_TOKEN.cancel();
     }));
 
-    if let Err(error) = buildernet_orderflow_proxy::run(OrderflowIngressArgs::parse()).await {
-        eprintln!("Error: {error:?}");
-        std::process::exit(1);
+    let mut sigterm = tokio::signal::unix::signal(SignalKind::terminate())
+        .expect("failed to install signal handler");
+
+    tokio::select! {
+        Err(error) = buildernet_orderflow_proxy::run(OrderflowIngressArgs::parse()) => {
+            eprintln!("Error: {error:?}");
+        }
+        _ = sigterm.recv() => {
+            tracing::warn!("Received SIGTERM, shutting down all tasks...");
+        }
+        _ = tokio::signal::ctrl_c() => {
+            tracing::warn!("Received SIGINT, shutting down all tasks...");
+        }
+    }
+    SHUTDOWN_TOKEN.cancel();
+
+    cleanup().await;
+}
+
+/// Cleans up all long-lived tasks by awaiting their join handles.
+async fn cleanup() {
+    SHUTDOWN_TOKEN.cancelled().await;
+
+    let tasks = std::mem::take(TASKS.write().expect("not poisoned").deref_mut());
+
+    if tasks.is_empty() {
+        return;
+    }
+
+    let Ok(results) = tokio::time::timeout(Duration::from_secs(5), join_all(tasks)).await else {
+        eprintln!("Timed out waiting for tasks to shut down");
+        return;
+    };
+
+    for result in results {
+        if let Err(e) = result {
+            eprintln!("Error while cleaning up task {}: {}", e.name, e.err);
+        }
     }
 }

--- a/src/statics.rs
+++ b/src/statics.rs
@@ -1,0 +1,22 @@
+//! Module containing static variables used throughout the application.
+
+use std::{
+    sync::{LazyLock, RwLock},
+    time::Instant,
+};
+
+use tokio_util::sync::CancellationToken;
+
+use crate::{builderhub::LocalPeerStore, types::LongLivedTask};
+
+/// A global shutdown token that can be used to signal shutdown to long-lived tasks.
+pub static SHUTDOWN_TOKEN: LazyLock<CancellationToken> = LazyLock::new(CancellationToken::new);
+
+/// The collection of long-lived tasks that need graceful shutdown and cleanup of resources.
+pub static TASKS: LazyLock<RwLock<Vec<LongLivedTask>>> = LazyLock::new(|| RwLock::new(Vec::new()));
+
+/// An artificial timestamp used for duration clamping.
+pub static START: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+/// A local peer store to use in case we're running without BuilderHub.
+pub static LOCAL_PEER_STORE: LazyLock<LocalPeerStore> = LazyLock::new(LocalPeerStore::new);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,16 +2,10 @@ use alloy_eips::eip2718::EIP4844_TX_TYPE_ID;
 use alloy_primitives::Bytes;
 use alloy_rlp::{Buf as _, Header};
 use axum::http::HeaderValue;
-use std::{
-    sync::LazyLock,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 use time::UtcDateTime;
 
-use crate::{builderhub::LocalPeerStore, validation::MAINNET_CHAIN_ID};
-
-/// An artificial timestamp used for duration clamping.
-static START: LazyLock<Instant> = LazyLock::new(Instant::now);
+use crate::{statics::START, validation::MAINNET_CHAIN_ID};
 
 /// Clamp the instant to duration bucket since the start time.
 pub fn clamp_to_duration_bucket(time: Instant, duration: Duration) -> Instant {
@@ -24,8 +18,6 @@ pub fn clamp_to_duration_bucket(time: Instant, duration: Duration) -> Instant {
     // Add that Duration to the start time to get the clamped time.
     *START + clamped_duration
 }
-
-pub static LOCAL_PEER_STORE: LazyLock<LocalPeerStore> = LazyLock::new(LocalPeerStore::new);
 
 pub fn looks_like_canonical_blob_tx(raw_tx: &Bytes) -> bool {
     // For full check we could call TransactionSigned::decode_enveloped and fully try to decode it


### PR DESCRIPTION
This PR implements graceful shutdown of the orderflow proxy long-lived tasks by adding a global cancellation token and list of tasks. Upon detecting a shutdown signal or failure, all subscribed tasks are notified and their cleanup is performed before exiting.

This is still fairly primitive, a next iteration could look something like [reth_tasks](https://reth.rs/docs/reth_tasks/index.html) (ty mempirate for resource)