### PR TITLE
feat(simulation): support for PCAP files -- monitor bandwidth usage

### DIFF
--- a/simulation/justfile
+++ b/simulation/justfile
@@ -24,6 +24,7 @@ run scenario='buildernet.yaml': clean-container
 get-results:
         mkdir -p results
         @docker cp {{container-name}}:/root/shadow.data/hosts/proxy2/bundle_receipts_proxy2.parquet ./results/bundle_receipts_{{datetime_utc("%Y-%m-%d-%H-%M-%S")}}_runtime-`grep stop_time scenarios/buildernet.yaml | cut -d ":" -f 2 | xargs`_scale-`cat scenarios/buildernet.yaml | awk -v RS=' ' '/--scale/ { getline; print; exit }' | xargs`.parquet
+        @docker cp {{container-name}}:/root/shadow.data/hosts/proxy2/eth0.pcap ./results/proxy2_eth0_{{datetime_utc("%Y-%m-%d-%H-%M-%S")}}_runtime-`grep stop_time scenarios/buildernet.yaml | cut -d ":" -f 2 | xargs`_scale-`cat scenarios/buildernet.yaml | awk -v RS=' ' '/--scale/ { getline; print; exit }' | xargs`.pcap
 
 # View the logs of the given Shadow process
 logs process:

--- a/simulation/scenarios/buildernet.yaml
+++ b/simulation/scenarios/buildernet.yaml
@@ -15,6 +15,13 @@ experimental:
   # Use the new Rust TCP implementation for better performance
   use_new_tcp: true
 
+# Packet Capture (PCAP) files for bandwidth usage
+host_option_defaults:
+  pcap_enabled: true
+  # Shadow by default writes to disk the whole content of an IP packet to the PCAP. We clearly don't want that bloat,
+  # we mainly care about metadata. 20 bytes represents minimum IPv4 header size.
+  pcap_capture_size: 20
+
 # Intra-zone latencies: https://latency.azure.cloud63.fr
 # Inter-zone latencies: https://learn.microsoft.com/en-us/azure/networking/azure-network-latency
 network:


### PR DESCRIPTION
Packet Capture (PCAP) is a format for recording network traffic on files. It is used by tools by `tcpdump`,`tshark` and other APIs. 

Given that shadow simulation doesn't rely on the OS and intercept all syscalls for its emulation, using advanced tools like eBPF for inspecting sockets or packets is not possible. However, shadow exposes a feature to save network traffic generated during the simulation to PCAP files, so we can use that, and this PR adds support for it.