### PR TITLE
fix(indexer): rows backup cleanup logic

### DIFF
--- a/src/indexer/click/mod.rs
+++ b/src/indexer/click/mod.rs
@@ -84,10 +84,9 @@ impl<T: ClickhouseIndexableOrder> ClickhouseInserter<T> {
                     tracing::debug!(target: TARGET, order = T::ORDER_TYPE, ?quantities, "inserted batch to clickhouse");
                     IndexerMetrics::process_clickhouse_quantities(&quantities);
                     IndexerMetrics::record_clickhouse_batch_commit_time(start.elapsed());
+                    // Clear the backup rows.
+                    self.rows_backup.clear();
                 }
-
-                // Clear the backup rows.
-                self.rows_backup.clear();
             }
             Err(e) => {
                 IndexerMetrics::increment_clickhouse_commit_failures(e.to_string());


### PR DESCRIPTION
Fixes the condition introduced in #80, it makes sense but we should clear `rows_backup` only when the result of a clickhouse commit is non-zero quantities, meaning that we have actually written on the ch server.