### PR TITLE
chore: drop hickory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ thiserror = "2"
 uuid = { version = "1", features = ["serde"] }
 dashmap = "6"
 flate2 = { version = "1", features = ["zlib-rs"], default-features = false }
-reqwest = { version = "0.12", features = ["json", "hickory-dns"] }
+reqwest = { version = "0.12", features = ["json"] }
 strum = "0.27"
 strum_macros = "0.27"
 mini-moka = "0.10.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,6 @@ pub async fn run_with_listeners(
     info!(address = %local_signer, "Orderflow signer configured");
 
     let client = reqwest::Client::builder()
-        .hickory_dns(true)
         .timeout(Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECS))
         .pool_max_idle_per_host(DEFAULT_CONNECTION_LIMIT_PER_HOST)
         .connector_layer(utils::limit::ConnectionLimiterLayer::new(
@@ -280,7 +279,6 @@ async fn run_update_peers(
     task_executor: TaskExecutor,
 ) {
     let client = reqwest::Client::builder()
-        .hickory_dns(true)
         .timeout(Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECS))
         .build()
         .unwrap();
@@ -331,7 +329,6 @@ async fn run_update_peers(
                     // SAFETY: We expect the certificate to be valid. It's added as a root
                     // certificate.
                     client = reqwest::Client::builder()
-                        .hickory_dns(true)
                         .timeout(Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECS))
                         .https_only(true)
                         .pool_max_idle_per_host(DEFAULT_CONNECTION_LIMIT_PER_HOST)


### PR DESCRIPTION
A global OS-level DNS caching layer will be used instead on the machines running this software