### PR TITLE
chore: bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "buildernet-orderflow-proxy"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buildernet-orderflow-proxy"
-version = "0.1.0"
+version = "1.1.0"
 edition = "2021"
 publish = false
 build = "build.rs"


### PR DESCRIPTION
Start tracking version in `Cargo.toml` file. We skipped v1.0.0, but I considered that the code deployed on Friday 17th at commit 45a0b997befc6dd5a6ffbf693551ef64989f633b. There is a draft release for that.