### PR TITLE
chore(simulation): git-ignored testdata for shadow

### DIFF
--- a/simulation/testdata/.gitignore
+++ b/simulation/testdata/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore


### PR DESCRIPTION
Shadow simulation requires testdata to run with which might be private, and we don't want to commit it by mistake. As such, a `.gitignore` with a `*` directive has been added, as such testing data must be explicitly added to it.