### PR TITLE
fix(cli): bump default order cache size

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -127,11 +127,14 @@ pub struct IndexerArgs {
 #[derive(PartialEq, Eq, Clone, Debug, Args)]
 pub struct CacheArgs {
     /// The order cache TTL in seconds.
-    #[clap(long = "order-cache.ttl", default_value_t = 24)]
+    #[clap(long = "order-cache.ttl", default_value_t = 60)]
     pub order_cache_ttl: u64,
 
     /// The order cache size.
-    #[clap(long = "order-cache.size", default_value_t = 4096)]
+    ///
+    /// Defaults to 1,048,576 entries (~1 million). Since each entry is just a 32-byte hash, this
+    /// results in a maximum memory usage of ~32 MiB.
+    #[clap(long = "order-cache.size", default_value_t = 1_048_576)]
     pub order_cache_size: u64,
 
     /// The signer cache TTL in seconds.


### PR DESCRIPTION
The previous value was just 4096, leading to a max size of 128KiB. Some unexpected consequences of a small cache size is we might end up with duplicate entries inside the bundle receipts table because we might not filter away the same hash because of eviction strategy