### PR TITLE
fix(cli): ensure underscores in builder name, in accordance to builderhub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+
 - Global metrics prefix from `orderflow_proxy` to `flowproxy_`.
 - Histograms are now actual histograms, not summaries.
 - Percentages are now integers from 0 to 100, instead of floats from 0.0 to 1.0.
 - Increase default order cache capacity to 1,048,576 entries (32 MiB).
 - Add `--io-threads` (`IO_THREADS`) and `--compute-threads` (`COMPUTE_THREADS`) CLI flags, defaults to 4 and 2 respectively.
+- Override dashes to underscore in value provided to CLI flag `--builder-name`.
+

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -169,7 +169,8 @@ pub struct OrderflowIngressArgs {
     #[clap(long, value_hint = ValueHint::Url, env = "BUILDER_READY_ENDPOINT", id = "BUILDER_READY_ENDPOINT", default_value = "http://127.0.0.1:6070")]
     pub builder_ready_endpoint: Option<String>,
 
-    /// The name of the local builder. For consistency with BuilderHub data, dashes will be replaced with underscores.
+    /// The name of the local builder. For consistency with BuilderHub data, dashes will be
+    /// replaced with underscores.
     #[clap(long, env = "BUILDERNET_NODE_NAME", id = "BUILDERNET_NODE_NAME", value_parser = replace_dashes_with_underscores)]
     pub builder_name: String,
 


### PR DESCRIPTION
Otherwise in data saved to clickhouse we might have some dashes and some underscore when we're referring to the same builder name.