### PR TITLE
Actually reproducible builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,21 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
+    inputs:
+      draft-release:
+        default: false
+        description: "Draft Release"
+        required: false
+        type: boolean
+      build-binary:
+        default: true
+        description: "Build Binary"
+        required: false
+        type: boolean
 
 jobs:
   extract-version:
@@ -34,17 +48,74 @@ jobs:
   build:
     name: Build binary
     needs: extract-version
+    if: ${{ github.event.inputs.build-binary == 'true' || github.event_name == 'push'}} # when manually triggered or version tagged
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: rui314/setup-mold@v1
-      - uses: extractions/setup-just@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Build reproducible binary
-        run: just build-reproducible
+      - name: Build reproducible binary with Docker
+        run: |
+          docker build -f Dockerfile.reproducible -t flowproxy:release .
+
+      - name: Extract binary from Docker image
+        run: |
+          # Create a temporary container and copy the binary
+          docker create --name temp-container flowproxy:release
+          docker cp temp-container:/flowproxy ./flowproxy
+          docker rm temp-container
+
+      - name: Calculate SHA256
+        id: sha256
+        run: |
+          sha256sum flowproxy > flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256
+          echo "hash=$(cat flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "Binary SHA256: $(cat flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256)"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: flowproxy-${{ needs.extract-version.outputs.VERSION }}-x86_64-unknown-linux-gnu
-          path: target/x86_64-unknown-linux-gnu/reproducible/flowproxy
+          path: |
+            flowproxy
+            flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256
+
+  draft-release:
+    name: Draft release
+    if: ${{ github.event.inputs.draft-release == 'true' || github.event_name == 'push'}} # when manually triggered or version tagged
+    needs: [extract-version, build]
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.extract-version.outputs.VERSION }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: artifacts
+      - name: Record artifacts checksums
+        working-directory: artifacts
+        run: |
+          find ./ || true
+          for file in *; do sha256sum "$file" >> sha256sums.txt; done;
+          cat sha256sums.txt
+      - name: Create release draft
+        uses: softprops/action-gh-release@v2.0.5
+        id: create-release-draft
+        with:
+          draft: true
+          files: artifacts/*
+          generate_release_notes: true
+          name: ${{ env.VERSION }}
+          tag_name: ${{ env.VERSION }}
+      - name: Release URL
+        run: |
+          echo "### Release created: ${{ steps.create-release-draft.outputs.url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -8,26 +8,77 @@ on:
 jobs:
   build:
     name: build reproducible binaries
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            machine: machine-1
+          - runner: ubuntu-22.04
+            machine: machine-2
     steps:
       - uses: actions/checkout@v5
-      - uses: rui314/setup-mold@v1
-      - uses: extractions/setup-just@v3
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build reproducible binary with Docker
+        run: |
+          docker build -f Dockerfile.reproducible -t flowproxy:reproducible .
+      - name: Extract binary from Docker image
+        run: |
+          # Create a temporary container and copy the binary
+          docker create --name temp-container flowproxy:reproducible
+          docker cp temp-container:/flowproxy ./flowproxy
+          docker rm temp-container
+      - name: Calculate SHA256
+        id: sha256
+        run: |
+          sha256sum flowproxy > flowproxy.sha256
+          echo "hash=$(cat flowproxy.sha256 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "Binary SHA256 on ${{ matrix.machine }}: $(cat flowproxy.sha256)"
+      - name: Upload the hash
+        uses: actions/upload-artifact@v4
         with:
-          target: x86_64-unknown-linux-gnu
-      - name: Install cargo-cache
+          name: flowproxy-${{ matrix.machine }}
+          path: |
+            flowproxy.sha256
+          retention-days: 1
+
+  compare:
+    name: compare reproducible binaries
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts from machine-1
+        uses: actions/download-artifact@v4
+        with:
+          name: flowproxy-machine-1
+          path: machine-1/
+      - name: Download artifacts from machine-2
+        uses: actions/download-artifact@v4
+        with:
+          name: flowproxy-machine-2
+          path: machine-2/
+      - name: Compare SHA256 hashes
         run: |
-          cargo install cargo-cache
-      - name: Build reproducible binary
-        run: |
-          just build-reproducible
-          mv target/x86_64-unknown-linux-gnu/reproducible/flowproxy flowproxy-1
-      - name: Clean cache
-        run: cargo clean && cargo cache -a
-      - name: Build reproducible binary again
-        run: |
-          just build-reproducible
-          mv target/x86_64-unknown-linux-gnu/reproducible/flowproxy flowproxy-2
-      - name: Compare binaries
-        run: cmp flowproxy-1 flowproxy-2
+          echo "=== SHA256 Comparison ==="
+          echo "Machine 1 hash:"
+          cat machine-1/flowproxy.sha256
+          echo "Machine 2 hash:"
+          cat machine-2/flowproxy.sha256
+
+          HASH1=$(cat machine-1/flowproxy.sha256 | cut -d' ' -f1)
+          HASH2=$(cat machine-2/flowproxy.sha256 | cut -d' ' -f1)
+
+          echo "Extracted hashes:"
+          echo "Machine 1: $HASH1"
+          echo "Machine 2: $HASH2"
+
+          if [ "$HASH1" = "$HASH2" ]; then
+            echo "✅ SUCCESS: Binaries are identical (reproducible build verified)"
+            echo "SHA256: $HASH1"
+          else
+            echo "❌ FAILURE: Binaries differ (reproducible build failed)"
+            echo "Machine 1 SHA256: $HASH1"
+            echo "Machine 2 SHA256: $HASH2"
+            exit 1
+          fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,8 @@ harness = false
 default = ["jemalloc"]
 # Enable jemalloc as the global allocator
 jemalloc = ["dep:tikv-jemallocator"]
+# Enable jemalloc with unprefixed malloc (recommended for reproducible builds)
+jemalloc-unprefixed = ["jemalloc", "tikv-jemallocator/unprefixed_malloc_on_supported_platforms"]
 
 # Speed up compilation time for dev builds by reducing emitted debug info.
 # NOTE: Debuggers may provide less useful information with this setting.

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -1,0 +1,14 @@
+ARG RUST_TOOLCHAIN=1.89.0
+FROM docker.io/rust:$RUST_TOOLCHAIN-trixie AS builder
+
+# Switch to snapshot repository
+RUN sed -i '/^# http/{N;s|^# \(http[^ ]*\)\nURIs: .*|# \1\nURIs: \1|}' /etc/apt/sources.list.d/debian.sources
+RUN apt-get -o Acquire::Check-Valid-Until=false update && \
+    apt-get install -y libjemalloc-dev just
+WORKDIR /build
+COPY . .
+RUN SOURCE_DATE_EPOCH=1730000000 just build-reproducible
+
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:4dd5cc58bb27cf9da5960f2a202cecf6c1c05c6ccbf0cda1b8ac24aeb428ca1a
+COPY --from=builder /build/target/x86_64-unknown-linux-gnu/reproducible/flowproxy /flowproxy
+ENTRYPOINT ["/flowproxy"]

--- a/justfile
+++ b/justfile
@@ -19,8 +19,9 @@ build-reproducible:
   RUSTFLAGS="-C symbol-mangling-version=v0 -C strip=none -C link-arg=-Wl,--build-id=none -C metadata='' --remap-path-prefix $(pwd)=." \
   LC_ALL=C \
   TZ=UTC \
-  SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)" \
-  cargo build --profile reproducible --locked --target x86_64-unknown-linux-gnu
+  SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(git log -1 --pretty=%ct)}" \
+  JEMALLOC_OVERRIDE=/usr/lib/x86_64-linux-gnu/libjemalloc.a \
+  cargo build --profile reproducible --locked --target x86_64-unknown-linux-gnu --features jemalloc-unprefixed
 
 # Provision the database and create the required tables.
 provision-db:


### PR DESCRIPTION
The previous implementation of reproducible builds did not produce identical binaries on sufficiently different OS/hardware. This PR address it:
- Switch to using jemalloc-sys from Debian repos instead of building it from source. A Debian version is [reproducible](https://tests.reproducible-builds.org/debian/rb-pkg/trixie/amd64/jemalloc.html) which is [hard to achieve](https://github.com/NixOS/nixpkgs/issues/380852) if you build it from source.
- Run the build in the Docker container with pinned dependencies (including Debian repos)
- Refactor reproducible-build pipeline to build inside the container and two different runners with different OS version (ubuntu24 vs ubuntu22)
- Refactor release pipeline to build inside the container. Create a release for tags and upload the artifacts. Previous implementation only allowed for short term storage.