### PR TITLE
Better artifacts handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,8 +106,7 @@ jobs:
       - name: Record artifacts checksums
         working-directory: artifacts
         run: |
-          find ./ || true
-          for file in *; do sha256sum "$file" >> sha256sums.txt; done;
+          find ./ -type f -exec sha256sum {} \; >> sha256sums.txt
           cat sha256sums.txt
       - name: Create release draft
         uses: softprops/action-gh-release@v2.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,8 @@ jobs:
       - name: Calculate SHA256
         id: sha256
         run: |
-          sha256sum ./target/flowproxy > flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256
+          mv ./target/flowproxy flowproxy-${{ needs.extract-version.outputs.VERSION }}-x86_64-unknown-linux-gnu
+          sha256sum flowproxy-${{ needs.extract-version.outputs.VERSION }}-x86_64-unknown-linux-gnu > flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256
           echo "hash=$(cat flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
           echo "Binary SHA256: $(cat flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256)"
 
@@ -83,7 +84,7 @@ jobs:
         with:
           name: flowproxy-${{ needs.extract-version.outputs.VERSION }}-x86_64-unknown-linux-gnu
           path: |
-            ./target/flowproxy
+            flowproxy-${{ needs.extract-version.outputs.VERSION }}-x86_64-unknown-linux-gnu
             flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256
 
   draft-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,24 +55,26 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Install rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
       - name: Build reproducible binary with Docker
         run: |
-          docker build -f Dockerfile.reproducible -t flowproxy:release .
-
-      - name: Extract binary from Docker image
-        run: |
-          # Create a temporary container and copy the binary
-          docker create --name temp-container flowproxy:release
-          docker cp temp-container:/flowproxy ./flowproxy
-          docker rm temp-container
+          RUST_TOOLCHAIN=$(rustc --version | cut -d' ' -f2)
+          docker build -f Dockerfile.reproducible \
+          --build-arg "RUST_TOOLCHAIN=${RUST_TOOLCHAIN}" \
+          -t flowproxy:release \
+          --output type=local,dest=./target .
 
       - name: Calculate SHA256
         id: sha256
         run: |
-          sha256sum flowproxy > flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256
+          sha256sum ./target/flowproxy > flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256
           echo "hash=$(cat flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
           echo "Binary SHA256: $(cat flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256)"
 
@@ -81,7 +83,7 @@ jobs:
         with:
           name: flowproxy-${{ needs.extract-version.outputs.VERSION }}-x86_64-unknown-linux-gnu
           path: |
-            flowproxy
+            ./target/flowproxy
             flowproxy-${{ needs.extract-version.outputs.VERSION }}.sha256
 
   draft-release:

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -18,21 +18,26 @@ jobs:
             machine: machine-2
     steps:
       - uses: actions/checkout@v5
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Install rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
       - name: Build reproducible binary with Docker
         run: |
-          docker build -f Dockerfile.reproducible -t flowproxy:reproducible .
-      - name: Extract binary from Docker image
-        run: |
-          # Create a temporary container and copy the binary
-          docker create --name temp-container flowproxy:reproducible
-          docker cp temp-container:/flowproxy ./flowproxy
-          docker rm temp-container
+          RUST_TOOLCHAIN=$(rustc --version | cut -d' ' -f2)
+          docker build -f Dockerfile.reproducible \
+          --build-arg "RUST_TOOLCHAIN=${RUST_TOOLCHAIN}" \
+          -t flowproxy:reproducible \
+          --output type=local,dest=./target .
+
       - name: Calculate SHA256
         id: sha256
         run: |
-          sha256sum flowproxy > flowproxy.sha256
+          sha256sum ./target/flowproxy > flowproxy.sha256
           echo "hash=$(cat flowproxy.sha256 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
           echo "Binary SHA256 on ${{ matrix.machine }}: $(cat flowproxy.sha256)"
       - name: Upload the hash

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -9,6 +9,5 @@ WORKDIR /build
 COPY . .
 RUN SOURCE_DATE_EPOCH=1730000000 just build-reproducible
 
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:4dd5cc58bb27cf9da5960f2a202cecf6c1c05c6ccbf0cda1b8ac24aeb428ca1a
-COPY --from=builder /build/target/x86_64-unknown-linux-gnu/reproducible/flowproxy /flowproxy
-ENTRYPOINT ["/flowproxy"]
+FROM scratch AS artifacts
+COPY --from=builder /build/target/x86_64-unknown-linux-gnu/reproducible/flowproxy /


### PR DESCRIPTION
- Set Docket image Rust version for building the binary by parsing a version configured for the project. That is to avoid manually updating Docker images when the Rust version bumps
- Consume build artifacts directly from the Docker image that built it using `--output` flag. Previously, we used a separate step to create a dummy container just to copy the artifacts.
- Replace release stage in the Docker image since we don't publish Docker images